### PR TITLE
Legg til info om tilgjengelighet for oppdrag

### DIFF
--- a/source/gdpr.md
+++ b/source/gdpr.md
@@ -8,6 +8,9 @@ Vi sletter epost- og SMS-varsler 3 år etter siste gang de ble forsøkt sendt.
 ## Signeringsoppdrag
 Vi sletter signeringsoppdrag 3 år etter at arkivbehov opphører. Det betyr at hvis en avsender oppretter et oppdrag i dag, så vil det ta 40 dager (eller 50 år hvis avsender bruker langtidsarkiv) før selve dokumentet blir slettet. 3 år etter dette sletter vi oppdraget med tilhørende data. Tilhørende data er jobb-events, kø for jobbendringer, informasjon om videresending til postkassen, varsler, undertegnere og selve oppdraget.
 
+### Tilgjengelighet for undertegner
+Oppdraget er tilgjengelig for undertegner i 24 timer etter signering. Grunnen til at det ikke er 40 dager eller 50 år er fordi vi ikke skal måtte innhente godkjente villkår fra undertegner - dette vil komplisere signeringsflyten. Ved å ha mulighet til å hente det inn i noe tid etter signering så gir vi de som ikke skjønte at de måtte laste det ned en sjanse til å prøve igjen.
+
 ## Brukere
 Brukere kan deaktiveres fra web i avsenderportalen, av kontoforvaltere i den aktuelle virksomheten, eller av Posten og Difi gjennom administrasjonsportalen. En deaktivert bruker vil anonymiseres og slettes etter følgende regler:
 * Anonymisering: En bruker anonymiseres 3 år etter at hun ble deaktivert.


### PR DESCRIPTION
Det er fint å understreke i GDPR hvorfor ikke undertegner kan laste det ned like lenge som virksomheten som lagde det.