### PR TITLE
Oppdater signeringsflyt - adressering uten fnr

### DIFF
--- a/source/signeringsflyt.rst
+++ b/source/signeringsflyt.rst
@@ -54,7 +54,7 @@ Flyten ser typisk slik ut:
 Adressering uten fødselsnummer
 _______________________________
 
- En signeringsflyt hvor man får tilgang til portalen ved en lenke og et engangspassord.
+En signeringsflyt hvor man får tilgang til portalen ved en lenke og et engangspassord.
 
 #. Avsender oppretter et oppdrag gjennom API eller fra web i avsenderportalen
 #. Undertegner mottar en unik lenke og engangskode til oppdrag på e-post eller SMS

--- a/source/signeringsflyt.rst
+++ b/source/signeringsflyt.rst
@@ -54,7 +54,7 @@ Flyten ser typisk slik ut:
 Adressering uten fødselsnummer
 _______________________________
 
- En signeringsflyt hvor man får tilgang til portalen vha en lenke og et engangspassord. Se bildeguide her.
+ En signeringsflyt hvor man får tilgang til portalen ved en lenke og et engangspassord.
 
 #. Avsender oppretter et oppdrag gjennom API eller fra web i avsenderportalen
 #. Undertegner mottar en unik lenke og engangskode til oppdrag på e-post eller SMS


### PR DESCRIPTION
Fjernet tekst om bildeguide som ikke er `her`