### PR TITLE
Litt housekeeping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ help:
 
 .PHONY: help Makefile
 
+# Sphinx autobuild
+autobuild:
+	@sphinx-autobuild "$(SOURCEDIR)" "$(BUILDDIR)/html" $(SPHINXOPTS) $(O)
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Sources for building the documentation site at [signering-docs.readthedocs.io](h
 
    Building the documentation site with [Sphinx](http://www.sphinx-doc.org) requires Python v3:
 
-   ```
+   ```shell
    brew install python
    ```
 
@@ -20,7 +20,7 @@ Sources for building the documentation site at [signering-docs.readthedocs.io](h
 
 3. **Install dependencies for building the documentation**
 
-   ```
+   ```shell
    pip install sphinx_rtd_theme
    pip install recommonmark
    pip install sphinx-tabs
@@ -28,7 +28,7 @@ Sources for building the documentation site at [signering-docs.readthedocs.io](h
    ```
 
 4. **Do a build to verify everything works**
-   ```
+   ```shell
    make clean html
    ```
 
@@ -38,7 +38,7 @@ Sources for building the documentation site at [signering-docs.readthedocs.io](h
 ### Local development
 
 To run a self-updating webserver using `sphinx-autobuild`:
-```
+```shell
 make autobuild
 ```
 
@@ -49,7 +49,7 @@ The site is continuously built when changes are made to the sources.
 
 To build the site, run:
 
-```
+```shell
 make clean html
 ```
 
@@ -61,7 +61,7 @@ make clean html
 
 If not already installed, install [pandoc](https://pandoc.org/) with e.g. `brew install pandoc`.
 
-```bash
+```shell
 pandoc markdown-file.md --from gfm --to rst -s -o output-file.rst --wrap=preserve
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,68 @@
-# signering-docs [![Documentation Status](https://readthedocs.org/projects/signering-docs/badge/?version=latest)](https://signering-docs.readthedocs.io/en/latest/?badge=latest)
+# [Posten signering](https://signering.posten.no) documentation site
 
-## To build:
+Sources for building the documentation site at [signering-docs.readthedocs.io](https://signering-docs.readthedocs.io)
 
-### 1. Installer Python
-```
-brew install python #python 3
-```
-### 2. Link Python 3
+[![Documentation Status](https://readthedocs.org/projects/signering-docs/badge/?version=latest)](https://signering-docs.readthedocs.io/en/latest/?badge=latest)
 
-Link ``python3`` as described in [Stackoverflow](https://stackoverflow.com/a/49711594/1765749). By adding it first in path, it will be chosen before the really old one installed by default on macOS.
+## ✅ Prerequisites
 
-### 3. Install all dependencies needed for the documentation
+1. **Install Python 3**
+
+   Building the documentation site with [Sphinx](http://www.sphinx-doc.org) requires Python v3:
+
+   ```
+   brew install python
+   ```
+
+2. **Link Python 3**
+
+   Link ``python3`` as described in [Stackoverflow](https://stackoverflow.com/a/49711594/1765749). By adding it first in `PATH` environment variable, it will be chosen before the really old one installed by default on macOS.
+
+3. **Install dependencies for building the documentation**
+
+   ```
+   pip install sphinx_rtd_theme
+   pip install recommonmark
+   pip install sphinx-tabs
+   pip install sphinx-autobuild
+   ```
+
+4. **Do a build to verify everything works**
+   ```
+   make clean html
+   ```
+
+
+## 🏗 Building
+
+### Local development
+
+To run a self-updating webserver using `sphinx-autobuild`:
 ```
-pip install sphinx_rtd_theme
-pip install recommonmark
-pip install sphinx-tabs
-pip install sphinx-autobuild
-make html
+make autobuild
 ```
 
-To run with autobuild as webserver:
+The site is continuously built when changes are made to the sources.
+
+
+### Building the site
+
+To build the site, run:
+
 ```
-sphinx-autobuild source build/html
+make clean html
 ```
 
-## To convert markdown to reStructuredText
-```
-brew install pandoc
-pandoc manuell-portal-integrasjon.md --from gfm --to rst -s -o manuell-portal-integrasjon.rst --wrap=preserve
+
+
+## 🛠 Tools
+
+### Convert markdown to reStructuredText
+
+If not already installed, install [pandoc](https://pandoc.org/) with e.g. `brew install pandoc`.
+
+```bash
+pandoc markdown-file.md --from gfm --to rst -s -o output-file.rst --wrap=preserve
 ```
 
-It is important to use `wrap=preserve` to avoid splitting one-liners into multiple lines.
+The example converts [GitHub Flavored Markdown](https://github.github.com/gfm/) using `--from gfm`. Substitute the source format with [something else](https://pandoc.org/MANUAL.html#option--from) if you need to. It is important to use `wrap=preserve` to avoid splitting one-liners into multiple lines.

--- a/source/adressering-av-undertegner.rst
+++ b/source/adressering-av-undertegner.rst
@@ -24,7 +24,7 @@ Posten signering sender ut varsel om signeringsoppdrag til undertegner på e-pos
 - adressere uten fødselsnummer (N.B: Kun hvis privat virksomhet)
 
 
-Det signerte dokumenter vil inneholde navn på undertegner og hvilken elektronisk ID som ble brukt. Man kan for øvrig velge hvilken :ref:`identifikator man ønsker i signerte dokumenter <identifisereUndertegnere>`. 
+Det signerte dokumenter vil inneholde navn på undertegner og hvilken elektronisk ID som ble brukt. Man kan for øvrig velge hvilken :ref:`identifikator man ønsker i signerte dokumenter <identifisereUndertegnere>`.
 
 
 Adressering med fødselsnummer
@@ -35,7 +35,7 @@ Ved :ref:`Signering i portalflyt med fødselsnummer <signering-i-portalflyt-med-
 
 Ved :ref:`signering-i-direkteflyt` er undertegner logget inn i avsenders system, og det er da avsender som er ansvarlig for å sende undertegner til riktig lenke i signeringstjenesten.
 
-Når du som avsender velger adressering med fødselsnummer, kan du velge å inkludere fødselsnummeret i det signerte dokumentet. 
+Når du som avsender velger adressering med fødselsnummer, kan du velge å inkludere fødselsnummeret i det signerte dokumentet.
 
 
 Adressering uten fødselsnummer
@@ -74,7 +74,7 @@ For **offentlige virksomheter** gjør vi oppslag i `Kontakt- og reservasjonsregi
 
 
 Bruk av Kontakt- og reservasjonsregisteret
-____________________________________________
+============================================
 
 Ytterligere informasjon rundt bruk av Kontakt- og reservarsjonregisteret
 
@@ -83,6 +83,3 @@ Ytterligere informasjon rundt bruk av Kontakt- og reservarsjonregisteret
  - Reservasjon ved utsatte førstegangsvarsler: I scenariet der tjenesteeier har satt en kjedet rekkefølge på undertegnerne, og førstegangsvarsel skal sendes til en undertegner som i perioden mellom oppdraget ble opprettet og førstegangsvarsel skal sendes har reservert seg mot elektronisk kommunikasjon, så vil hele oppdraget feile.
  - Reservasjon ved påminnelser: Hvis sluttbrukeren har reservert seg etter at oppdraget ble opprettet, men oppdraget allerede er aktivert, vil det ikke bli sendt påminnelser (e-post/SMS), men oppdraget vil heller ikke feile før signeringsfristen eventuelt løper ut.
  - Oppdrag med overstyrt kontaktinformasjon med utenlandsk mobilnummer vil bli avvist, mens utenlandske mobilnumre fra Kontakt- og reservasjonsregisteret vil bli ignorert.
-
-
-

--- a/source/buy-enterprise-certificates.rst
+++ b/source/buy-enterprise-certificates.rst
@@ -17,13 +17,13 @@ A test certificate must be used against our test environment. The test certifica
 
    .. group-tab:: Buypass
 
-    A test certificate can be bought from the Buypass home page. Please `click here <https://www.buypass.no/produkter/virksomhetssertifikat-esegl>`_ for the Norwegian version, or `here <https://www.buypass.com/products/eseal--and-enterprise-certificate>`_ for the English version. Please select *Test-sertifikat/Test certificate*.
+    A test certificate can be bought from Buypass, on either their `Norwegian <https://www.buypass.no/produkter/virksomhetssertifikat-esegl>`__ or `English <https://www.buypass.com/products/eseal--and-enterprise-certificate>`__ site. Please select *Test-sertifikat/Test certificate*.
 
     When buying an enterprise certificate from Buypass, you will receive an email containing two *.p12* files. The two files have different serial numbers, and these refer to certficates used for authentication and encryption (*autentisering og kryptering*) and signature (*signering*). You shall only use the one marked for authentication and encryption.
 
    .. group-tab:: Commfides
 
-    A test certificates can be bought from the Commfides home page. Please `click here <https://www.commfides.com/en/commfides-virksomhetssertifikat/>`_ for the Norwegian version, or `here <https://www.commfides.com/en/commfides-virksomhetssertifikat/>`_ for the English version. Please see *Bestill Testsertifikat/Order Test Certificate*.
+    A test certificates can be bought from Commfides, on either their `Norwegian <https://www.commfides.com/en/commfides-virksomhetssertifikat/>`__ or `English <https://www.commfides.com/en/commfides-virksomhetssertifikat/>`__ site. Please see *Bestill Testsertifikat/Order Test Certificate*.
 
     When buying an enterprise certificate from Commfides, you will receive an email containing three *.p12* files: *auth*, *enc* and *sign*. You shall use the one named *auth* with :code:`Key Usage = Digital Signature`.
 
@@ -42,12 +42,12 @@ Production environment
 
    .. group-tab:: Buypass
 
-    A production certificate can be bought from the Buypass home page. Please `click here <https://www.buypass.no/produkter/virksomhetssertifikat-esegl>`_ for the Norwegian version, or `here <https://www.buypass.com/products/eseal--and-enterprise-certificate>`_ for the English version. Please select *Standard sertifikat/Standard Certificate*.
+    A production certificate can be bought from Buypass, on either their `Norwegian <https://www.buypass.no/produkter/virksomhetssertifikat-esegl>`__ or `English <https://www.buypass.com/products/eseal--and-enterprise-certificate>`__ site. Please select *Standard sertifikat/Standard Certificate*.
 
     When buying an enterprise certificate from Buypass, you will receive an email containing two *.p12* files. The two files have different serial numbers, and these refer to certficates used for authentication and encryption (*autentisering og kryptering*) and signature (*signering*). You shall only use the one marked for authentication and encryption.
 
    .. group-tab:: Commfides
 
-    A production can be bought from the Commfides home page. Please `click here <https://www.commfides.com/en/commfides-virksomhetssertifikat/>`_ for the Norwegian version, or `here <https://www.commfides.com/en/commfides-virksomhetssertifikat/>`_ for the English version. Please see *Bestill Virksomhetssertifikat/Order Enterprise Certificate* for use in a production environment.
+    A production can be bought from Commfides, on either their `Norwegian <https://www.commfides.com/en/commfides-virksomhetssertifikat/>`__ or `English <https://www.commfides.com/en/commfides-virksomhetssertifikat/>`__ site. Please see *Bestill Virksomhetssertifikat/Order Enterprise Certificate* for use in a production environment.
 
     When buying an enterprise certificate from Commfides, you will receive an email containing three *.p12* files: *auth*, *enc* and *sign*. You shall use the one named *auth* with :code:`Key Usage = Digital Signature`.

--- a/source/create-client-configuration.rst
+++ b/source/create-client-configuration.rst
@@ -58,7 +58,7 @@ A client configuration includes all organization specific configuration and all 
 
         Where :code:`ReadCertificate` is:
 
-        ..  code-block:: c#
+        ..  code-block:: none
 
             var pathToSecrets = $"{System.Environment.GetEnvironmentVariable("HOME")}/.microsoft/usersecrets/enterprise-certificate/secrets.json";
             _logger.LogDebug($"Reading certificate details from secrets file: {pathToSecrets}");
@@ -82,6 +82,3 @@ A client configuration includes all organization specific configuration and all 
 
 ..  NOTE::
     For organizations acting as brokers on behalf of multiple senders, you may specify the sender’s organization number on each signature job. The sender specified for a job will always take precedence over the :code:`globalSender` in :code:`ClientConfiguration`.
-
-
-

--- a/source/egen-integrasjon/dokumentpakke.rst
+++ b/source/egen-integrasjon/dokumentpakke.rst
@@ -3,7 +3,7 @@
 Dokumentpakken
 ***************
 
-Dokumentpakken i Posten signering er basert på ASiC-E standarden (`Associated Signature Containers, Extended form <http://www.etsi.org/deliver/etsi_ts/102900_102999/102918/01.03.01_60/ts_102918v010301p.pdf>`_). Profilen er lagd for å ligne på den som er brukt for `Digital postkasse til innbyggere <http://begrep.difi.no/SikkerDigitalPost>`_. Les mer om :ref:`profilen som er benyttet for ASiC <asicEStandards>` i slutten av dette dokumentet.
+Dokumentpakken i Posten signering er basert på ASiC‑E standarden (`Associated Signature Containers, Extended form <http://www.etsi.org/deliver/etsi_ts/102900_102999/102918/01.03.01_60/ts_102918v010301p.pdf>`_). Profilen er lagd for å ligne på den som er brukt for `Digital postkasse til innbyggere <http://begrep.difi.no/SikkerDigitalPost>`_. Les mer om :ref:`profilen som er benyttet for ASiC <asicEStandards>` i slutten av dette dokumentet.
 
 
 Innhold
@@ -151,10 +151,10 @@ Dokumentet pakkes i en dokumentpakke sammen med noe metadata i henhold til ASiC 
 ========================= ================================================================================================================================ =========================================================================================================================================================================================================
 Krav                      Felt                                                                                                                             Kommentar
 ========================= ================================================================================================================================ =========================================================================================================================================================================================================
-krav 6.1  [#etsi29]_       ASiC conformance                                                                                                                Skal være “ASiC-E XAdES”
-krav 8.1 [#etsi211]_       ASiC-E Media type identification                                                                                                Skal være “ASiC file extension is”.asice
-krav 8.2 [#etsi211]_       ASiC-E Signed data object                                                                                                       Alle filer utenfor META-INF katalogen skal være signert.
-krav 8.3.1 [#etsi212]_     ASiC-E XAdES signature                                                                                                          Det skal kun være en signatur i META-INF katalogen, med navn signatures.xml. Denne signaturen skal dekke alle andre filer i beholderen, og avsenderens virksomhetssertifikat skal benyttes for signering.
+krav 6.1  [#etsi29]_       ASiC conformance                                                                                                                Skal være “ASiC‑E XAdES”
+krav 8.1 [#etsi211]_       ASiC‑E Media type identification                                                                                                Skal være “ASiC file extension is”.asice
+krav 8.2 [#etsi211]_       ASiC‑E Signed data object                                                                                                       Alle filer utenfor META-INF katalogen skal være signert.
+krav 8.3.1 [#etsi212]_     ASiC‑E XAdES signature                                                                                                          Det skal kun være en signatur i META-INF katalogen, med navn signatures.xml. Denne signaturen skal dekke alle andre filer i beholderen, og avsenderens virksomhetssertifikat skal benyttes for signering.
 krav 8.3.2 [#etsi212]_     Requirements for the contents of Container” refererer til “6.2.2 punkt 4b) "META-INF/manifest.xml" if present […] i”ASiC":etsi1 Denne filen skal ikke være tilstede.
 ========================= ================================================================================================================================ =========================================================================================================================================================================================================
 

--- a/source/egen-integrasjon/sikkerhet.rst
+++ b/source/egen-integrasjon/sikkerhet.rst
@@ -1,7 +1,7 @@
 Sikkerhet
 **********
 
-Signeringstjenesten benytter to-veis TLS for å sikre konfidensialitet og meldingsintegritet på transportlaget. Dokumentpakken med dokumentet som skal signeres er integritetssikret med ASiC-E.
+Signeringstjenesten benytter to-veis TLS for å sikre konfidensialitet og meldingsintegritet på transportlaget. Dokumentpakken med dokumentet som skal signeres er integritetssikret med ASiC‑E.
 
 To-veis TLS
 =============

--- a/source/ordbok.rst
+++ b/source/ordbok.rst
@@ -37,7 +37,7 @@ Signeringsoppdrag i portalflyt
 
 Signeringsoppdrag i direkteflyt
 
-En :ref:`undertegner` starter en signering.
+En :ref:`undertegner-ordbok` starter en signering.
 
 Vi skal **ikke** bruke ord som *signeringsseremoni*.
 
@@ -53,6 +53,3 @@ API
 Vi bruker API om det å bruke API-et vårt.
 
 Vi skal **ikke** bruke ord som *bak-kanal-kall*.
-
-
-


### PR DESCRIPTION
Gir litt kjærlighet til dette repoet:

- kan kjøre `make autobuild` i stedet for `sphinx-autobuild source build/html`. Mindre tooling å veksle mellom på kommandolinjen.
- [bruker non-breaking hyphen i ASiC-E](
bc531e1). A.k.a
  Før:
  <img width="703" alt="Screenshot 2019-05-15 at 15 47 44" src="https://user-images.githubusercontent.com/174823/57780593-d526d580-7728-11e9-8108-ce5862725f75.png">
  Etter:
  <img width="656" alt="Screenshot 2019-05-15 at 15 45 48" src="https://user-images.githubusercontent.com/174823/57780469-9bee6580-7728-11e9-9ca6-baa702614c11.png">
- fjerner en del warns i bygging. ~Ikke mulig å fjerne warn om unparseable _C#_~ Fjernet warn om unparseable _C#_ ved å disable highlighting for spesifikt case som ikke funker p.g.a [bug i pygments](https://bitbucket.org/birkenfeld/pygments-main/issues/1334/highlighting-error-for-c)
- ph3tere README. [master](https://github.com/digipost/signering-docs/blob/master/README.md) vs. [denne branchen](https://github.com/digipost/signering-docs/blob/d91c99ab40d7a441253efcef84bc095d8a974731/README.md)