### PR TITLE
Document new email reminder to download PAdES

### DIFF
--- a/source/client-integration/portal-flow.rst
+++ b/source/client-integration/portal-flow.rst
@@ -30,6 +30,8 @@ Having problems integrating?
 
             Get help for your `HTTP integration here <https://github.com/digipost/signature-api-specification>`_.
 
+.. _portalIntegrationStep1:
+
 Step 1: Create signature job
 ==============================
 

--- a/source/egen-integrasjon/dokumentpakke.rst
+++ b/source/egen-integrasjon/dokumentpakke.rst
@@ -27,7 +27,7 @@ Manifest
 
 Filen ``manifest.xml`` følger skjemaet `direct-and-portal.xsd <https://github.com/digipost/signature-api-specification/blob/master/schema/xsd/direct-and-portal.xsd>`_, som igjen importerer `direct.xsd <https://github.com/digipost/signature-api-specification/blob/master/schema/xsd/direct.xsd>`_ og `portal.xsd <https://github.com/digipost/signature-api-specification/blob/master/schema/xsd/portal.xsd>`_.
 
-Se :ref:`directIntegrationStep1` og :ref:`egenPortalIntegrasjon` for eksempler på forskjellige måter elementene kan bygges opp.
+Se hvordan man man oppretter oppdrag i :ref:`direkteflyt <directIntegrationStep1>` og :ref:`portalflyt <portalIntegrationStep1>` for eksempler på forskjellige måter elementene kan bygges opp.
 
 .. _signaturesxml:
 

--- a/source/varsler-til-avsender.rst
+++ b/source/varsler-til-avsender.rst
@@ -6,40 +6,60 @@ Alle avsendere er registrert i tjenesten med e-postadresse, og varsler sendes de
 ..  NOTE::
     Det er kun brukeren som har opprettet signeringsoppdraget som vil få e-poster knyttet til et oppdrag.
 
-Det sendes ut varsler til avsender i to tilfeller:
+Det sendes ut varsler til avsender i tre tilfeller:
 
 1. **Når signeringsoppdrag endrer status**: Varselet inneholder en oversikt over samtlige undertegneres signeringsstatus. Det blir sendt én e-post for hver undertegner som "gjør noe", dvs. signerer eller avviser, eller når signeringsfristen er gått ut.
 
 2. **24 timer før signeringsfristen for ett oppdrag går ut**: Varselet sendes ut som en påminnelse til avsender om at noen fortsatt ikke har signert. Avsender kan da velge å utsette signeringsfristen, eller purre på undertegnerne ved å sende ekstra varsel. **N.B:** Varselet sendes kun hvis oppdragets opprinnelige signeringsfrist var mer enn 48 timer.
+
+3. **4 dager før arkivering av ferdigsignert dokument utløper**: Varselet sendes ut som en påminnelse til avsender dersom dokumentet er signert av alle mottakere, og *kun* dersom avsender ikke har lastet ned det ferdigsignerte dokumentet. Posten signering tilbyr :ref:`langtidslagring <langtidslagring>` for avsendere som ikke ønsker å måtte laste ned og ta vare på ferdigsignerte dokumenter.
 
 
 Varsel når signeringsoppdrag endrer status
 __________________________________________
 
 ..  tabs::
-      
+
     ..  tab:: Statusendring
-       
+
         **Emne**: Oppdatert signeringsstatus: Dokumentet er [*delvis signert*]/[*ferdig signert*]/[*ferdig, men ufullstendig*]
-        
+
         Hei!
         Vi vil informere deg om at dokumentet med referanse [*XXXX*] har endret status til [*delvis signert*]/[*ferdig signert*]/[*ferdig, men ufullstendig*].
-        
+
         Undertegner ********: [*Venter*]/[*Avvist*]/[*Signert*]/[*Sperret*]
-        
+
         Logg deg inn på [*https://signering.posten.no/virksomhet/#/*] for å (utsette fristen eller for å) se detaljer om dokumentet.
-        
+
         Hilsen Posten
 
     ..  tab:: Fristen går snart ut
-        
+
         **Emne**: Signeringsfristen går ut om 24 timer
-        
+
         Hei!
         Dkoumentet med referanse [*XXXX*] er fortsatt ikke signert av [*undertegnere*]. Det er nå kun 24 timer til signeringsfristen utløper. Du kan utsette fristen for signeringen ved å logge inn og klikke på "Utsett signeringsfrist". Om dokumentet ikek signeres innen fristen, stoppes prosessen, og du må eventuelt sende dokumentet på nytt for å hente inn signaturer.
-        
-        Logg deg inn på [*https://signering.posten.no/virksomhet/#/*] for å utsette fristen eller for å se detaljer om dokumentet.
-        
-        Hilsen Posten
-        
 
+        Logg deg inn på [*https://signering.posten.no/virksomhet/#/*] for å utsette fristen eller for å se detaljer om dokumentet.
+
+        Hilsen Posten
+
+
+Varsel før arkivering av ferdigsignert dokument utløper
+_______________________________________________________
+
+..  tabs::
+
+    ..  tab:: Arkiveringstid utløper snart
+
+        **Emne**: Påminnelse om å laste ned [ikke-sensitiv dokumenttittel] innen [arkivering utløper dato *minus* 1 dag]
+
+        Hei!
+
+        Husk å ta godt vare på signerte dokumenter.
+
+        Dokumentet **[ikke-sensitiv dokumenttittel]** (referanse: [refereanse]) er ikke lastet ned og vil slettes den **[arkivering utløper dato *minus* 1 dag]**. `Logg inn <https://test.signering.posten.no/virksomhet/#/logginn/privat>`_ for å laste ned dokumentet. Dette er siste påminnelse.
+
+        Trenger du et sikkert lagringsalternativ? Vi tilbyr `sikker og permanent lagring av dine signerte dokumenter <https://signering.posten.no/virksomhet/#/hjelp/lagring-og-validering/how-long>`_.
+
+        Hilsen Posten


### PR DESCRIPTION
Changes the [descriptions of notifications to senders](https://signering-docs.readthedocs.io/en/latest/varsler-til-avsender.html): 

---

<img width="716" alt="Screenshot 2019-09-10 at 14 49 36" src="https://user-images.githubusercontent.com/174823/64615244-76255480-d3da-11e9-88e6-7340a8801966.png">

---

<img width="717" alt="Screenshot 2019-09-10 at 14 49 46" src="https://user-images.githubusercontent.com/174823/64615249-7a517200-d3da-11e9-80bb-c99a9916e83d.png">
