### PR TITLE
En lettere utledbar rot-URL

### DIFF
--- a/source/client-integration/direct-flow.rst
+++ b/source/client-integration/direct-flow.rst
@@ -92,7 +92,7 @@ Step 1: Create signature job
 
         The flow starts when the sender sends a request to create the signature job to the API. This request is a `multipart message <https://en.wikipedia.org/wiki/MIME#Multipart_messages>`_ comprised of a document bundle part and a metadata part.
 
-        - The request is a ``HTTP POST`` to the resource ``<root-URL>/direct/signature-jobs``.
+        - The request is a ``HTTP POST`` to the resource ``api.<environment>.signering.posten.no/api/<organization-number>/direct/signature-jobs``, where ``<environment>`` is ``difiqa``, ``difitest`` or just remove the environment part for the production environment.
         - The document bundle is added to the multipart message with ``application/octet-stream`` as media type. See :ref:`informasjonOmDokumentpakken` for more information on the document bundle.
         - The metadata in the multipart request is defined by the ``direct-signature-job-request`` element. These are added with media type ``application/xml``.
 

--- a/source/client-integration/direct-flow.rst
+++ b/source/client-integration/direct-flow.rst
@@ -92,7 +92,7 @@ Step 1: Create signature job
 
         The flow starts when the sender sends a request to create the signature job to the API. This request is a `multipart message <https://en.wikipedia.org/wiki/MIME#Multipart_messages>`_ comprised of a document bundle part and a metadata part.
 
-        - The request is a ``HTTP POST`` to the resource ``<rot-URL>/direct/signature-jobs``.
+        - The request is a ``HTTP POST`` to the resource ``<root-URL>/direct/signature-jobs``.
         - The document bundle is added to the multipart message with ``application/octet-stream`` as media type. See :ref:`informasjonOmDokumentpakken` for more information on the document bundle.
         - The metadata in the multipart request is defined by the ``direct-signature-job-request`` element. These are added with media type ``application/xml``.
 

--- a/source/client-integration/portal-flow.rst
+++ b/source/client-integration/portal-flow.rst
@@ -93,7 +93,7 @@ Step 1: Create signature job
 
         The flow starts when the sender sends a request to create the signature job to the API. This request is a `multipart message <https://en.wikipedia.org/wiki/MIME#Multipart_messages>`_ comprised of a document bundle part and a metadata part.
 
-        - The request is a ``HTTP POST`` to the resource ``<rot-URL>/portal/signature-jobs``.
+        - The request is a ``HTTP POST`` to the resource ``<root-URL>/portal/signature-jobs``.
         - The document bundle is added to the multipart message with ``application/octet-stream`` as media type. See :ref:`informasjonOmDokumentpakken` for more information on the document bundle.
         - The metadata in the multipart request is defined by the ``portal-signature-job-request`` element. These are added with media type ``application/xml``.
 

--- a/source/client-integration/portal-flow.rst
+++ b/source/client-integration/portal-flow.rst
@@ -93,7 +93,8 @@ Step 1: Create signature job
 
         The flow starts when the sender sends a request to create the signature job to the API. This request is a `multipart message <https://en.wikipedia.org/wiki/MIME#Multipart_messages>`_ comprised of a document bundle part and a metadata part.
 
-        - The request is a ``HTTP POST`` to the resource ``<root-URL>/portal/signature-jobs``.
+
+        - The request is a ``HTTP POST`` to the resource ``api.<environment>.signering.posten.no/api/<organization-number>/portal/signature-jobs``, where ``<environment>`` is ``difiqa``, ``difitest`` or just remove the environment part for the production environment.
         - The document bundle is added to the multipart message with ``application/octet-stream`` as media type. See :ref:`informasjonOmDokumentpakken` for more information on the document bundle.
         - The metadata in the multipart request is defined by the ``portal-signature-job-request`` element. These are added with media type ``application/xml``.
 


### PR DESCRIPTION
Et resultat av digipost/signature-api-specification#135, hvor det er problemer knyttet til å finne ut hva URL er. 

![image](https://user-images.githubusercontent.com/720545/65602741-b1ac4b00-dfa4-11e9-8778-1a965e0c1cb0.png)
