### PR TITLE
Dokumentere begrensning på 80 tegn i tittel

### DIFF
--- a/source/opprette-oppdrag.rst
+++ b/source/opprette-oppdrag.rst
@@ -10,7 +10,7 @@ Ved opprettelse av signeringsoppdrag kan følgende felter angis:
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
 | Undertegner(e)            | **Obligatorisk**        | **Obligatorisk**  | se :ref:`adressering-av-undertegner`                          |
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
-| Tittel                    | **Obligatorisk**[#f3]_  | **Obligatorisk**  |                                                               |
+| Tittel                    | **Obligatorisk**        | **Obligatorisk**  | Maks 80 tegn [#f1]_                                           |
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
 | Signaturtype              | Valgfritt               | Valgfritt         | se :ref:`signaturtype`                                        |
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
@@ -20,9 +20,9 @@ Ved opprettelse av signeringsoppdrag kan følgende felter angis:
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
 | Undertegners identifikator| Valgfritt               | Valgfritt         | se :ref:`adressering-av-undertegner`                          |
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
-| Aktiveringstidspunkt      | Ikke overstyrbar [#f1]_ | Valgfritt         |                                                               |
+| Aktiveringstidspunkt      | Ikke overstyrbar [#f2]_ | Valgfritt         |                                                               |
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
-| Levetid                   | Ikke overstyrbar [#f2]_ | Valgfritt         |                                                               |
+| Levetid                   | Ikke overstyrbar [#f3]_ | Valgfritt         |                                                               |
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
 | E-postadresse             | Ikke relevant           | **Obligatorisk**  | se :ref:`varsler`                                             |
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
@@ -33,9 +33,9 @@ Ved opprettelse av signeringsoppdrag kan følgende felter angis:
 
 .. rubric:: Footnotes
 
-.. [#f1] Signeringsoppdrag i direkteflyt blir alltid aktivert øyeblikkelig etter opprettelse. *Standardverdi* er *øyeblikkelig etter opprettelse*.
-.. [#f2] Signeringsoppdrag i direkteflyt har alltid 30 dagers levetid for å unngå at et dokument blir signert uhensiktsmessig lenge etter opprettelsen av oppdraget. Eventuell frist fra avsenders perspektiv må kommuniseres og håndteres i avsenders tjenester.
-.. [#f3] Tittel kan ikke være lengre en 80 tegn.
+.. [#f1] Maks 80 tegn er tillatt for tittel i både `direkte- <https://github.com/digipost/signature-api-specification/blob/2.7/schema/xsd/direct.xsd#L68-L75>`_ og `portalflyt <https://github.com/digipost/signature-api-specification/blob/2.7/schema/xsd/portal.xsd#L98-L105>`_.
+.. [#f2] Signeringsoppdrag i direkteflyt blir alltid aktivert øyeblikkelig etter opprettelse. *Standardverdi* er *øyeblikkelig etter opprettelse*.
+.. [#f3] Signeringsoppdrag i direkteflyt har alltid 30 dagers levetid for å unngå at et dokument blir signert uhensiktsmessig lenge etter opprettelsen av oppdraget. Eventuell frist fra avsenders perspektiv må kommuniseres og håndteres i avsenders tjenester.
 
 For implementasjon for signeringsoppdrag i portalflyt, se  :ref:`portal-flow`, og for signeringsoppdrag i direkteflyt, se :ref:`direct-flow`.
 

--- a/source/opprette-oppdrag.rst
+++ b/source/opprette-oppdrag.rst
@@ -10,7 +10,7 @@ Ved opprettelse av signeringsoppdrag kan følgende felter angis:
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
 | Undertegner(e)            | **Obligatorisk**        | **Obligatorisk**  | se :ref:`adressering-av-undertegner`                          |
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
-| Tittel                    | **Obligatorisk**        | **Obligatorisk**  |                                                               |
+| Tittel                    | **Obligatorisk**[#f3]_  | **Obligatorisk**  |                                                               |
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
 | Signaturtype              | Valgfritt               | Valgfritt         | se :ref:`signaturtype`                                        |
 +---------------------------+-------------------------+-------------------+---------------------------------------------------------------+
@@ -35,6 +35,7 @@ Ved opprettelse av signeringsoppdrag kan følgende felter angis:
 
 .. [#f1] Signeringsoppdrag i direkteflyt blir alltid aktivert øyeblikkelig etter opprettelse. *Standardverdi* er *øyeblikkelig etter opprettelse*.
 .. [#f2] Signeringsoppdrag i direkteflyt har alltid 30 dagers levetid for å unngå at et dokument blir signert uhensiktsmessig lenge etter opprettelsen av oppdraget. Eventuell frist fra avsenders perspektiv må kommuniseres og håndteres i avsenders tjenester.
+.. [#f3] Tittel kan ikke være lengre en 80 tegn.
 
 For implementasjon for signeringsoppdrag i portalflyt, se  :ref:`portal-flow`, og for signeringsoppdrag i direkteflyt, se :ref:`direct-flow`.
 


### PR DESCRIPTION
Får følgende feil når tittel på dokumentet er lengre enn 80 tegn. 
Dette var dokumentert før, men ser ikke ut til å være dokumentert lengre. 

Angående 80 tegn lengde:
Digipost.Signature.Api.Client.Core.Exceptions.InvalidXmlException: The 'http://signering.posten.no/schema/v1:title' element is invalid - The value 'Dokument for signering med ganske langt filnavn som er mye lengre enn 80 tegn og bør ikke vises i sin helhet i signering' is invalid according to its datatype 'String' - The actual length is greater than the MaxLength value.