### PR TITLE
Correct description of doc retain time for signers

### DIFF
--- a/source/gdpr.rst
+++ b/source/gdpr.rst
@@ -19,7 +19,7 @@ We erase the signature request 3 years after the archiving requirement lapses. T
 Availability to the signer
 -------------------------------
 
-The request is available to the signer for 24 hours after signing. The reason this is not 40 days or 50 years is that we must not need to obtain approved terms from the signer, since this would complicate the signature flow. By making it possible to retrieve the request for some time after signing, we give those who did not realise they had to download it a chance to try again.
+After a signature request has been completed, the signer will have access to the signed document from the service for usually up to 40 days. However, the sender of the request :ref:`have some opportunities to delete <storage-delete-limitations>` the document earlier, if necessary. The reason for the limited availability for the signer is that we wish to avoid having to obtain approved terms from the signer, since this would complicate the signature flow. By making it possible to retrieve the request for some time after signing, we give those who did not realise they had to download it a chance to try again. The signer is free to download the document and store at their own discretion, and if possible, the signed document is also automatically forwarded to either Digipost or the signer's chosen `digital mailbox in DPI <https://eid.difi.no/en/digital-mailboxes>`_ for permanent storage.
 
 
 Users

--- a/source/lagring.rst
+++ b/source/lagring.rst
@@ -36,6 +36,8 @@ Senders can erase archived documents if they want to remove them from the archiv
 Senders using the sender portal can erase documents from there.
 For senders that integrate via API, documents can be erased via the REST interface.
 
+.. _storage-delete-limitations:
+
 Limitations
 _____________
 


### PR DESCRIPTION
Signert dokument er tilgjengelig for undertegnere i _opptil_ 40 dager, og ikke bare 24 timer som tidligere

Med opptil 40 dager, så betyr dette at begrensningene for avsender for å kunne slette dokumenter i et oppdrag er fortsatt 24 timer etter fullføring av oppdrag eller til vi gir opp å forsøke å sende til undertegners postkasse i opptil en uke. Det vil si at [punktene som står ang. begrensningene for sletting for avsender](https://signering-docs.readthedocs.io/en/latest/lagring.html#limitations) er fortsatt korrekte.

Jeg lar beskrivelsen i seksjonen [Storage](https://signering-docs.readthedocs.io/en/latest/lagring.html?highlight=24#limitations) forbli uendret, da de korrekt beskriver begrensninger for når en avsender kan slette. Jeg har i PR-en detaljert [GDPR](https://signering-docs.readthedocs.io/en/latest/gdpr.html)-beskrivelsen at signert dokument er tilgjengelig for undertegner i _minst_ 24 timer, og _opptil 40 dager_ med mindre man som avsender velger å slette det.


## Før:

<img width="738" alt="Screenshot 2023-08-30 at 11 44 47" src="https://github.com/digipost/signering-docs/assets/174823/8c83aeb1-9c84-4c37-8963-94e9c1d36e4e">



## Etter:

<img width="738" alt="Screenshot 2023-08-30 at 11 55 33" src="https://github.com/digipost/signering-docs/assets/174823/bd7b87a4-1fe3-4ff7-9608-37be12ecad5d">

