### PR TITLE
Replace occurences of Posten Norge with Posten Bring.

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -20,8 +20,8 @@
 # -- Project information -----------------------------------------------------
 
 project = u'Posten signering documentation'
-copyright = u'2019, Posten Norge AS'
-author = u'Posten Norge AS'
+copyright = u'2019, Posten Bring AS'
+author = u'Posten Bring AS'
 
 # The short X.Y version
 version = u''
@@ -154,7 +154,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'Postensigneringdocumentation.tex', u'Posten signering documentation Documentation',
-     u'Posten Norge AS', 'manual'),
+     u'Posten Bring AS', 'manual'),
 ]
 
 


### PR DESCRIPTION
Endre forfatter og rettighetshaver i konfigurasjonsfiler fra Posten Norge til Posten Bring. Dette gjøres som følge av at [selskapet har endret navn](https://www.mynewsdesk.com/no/posten-bring/pressreleases/posten-norge-as-blir-posten-bring-as-3257477).

I avsnittet om toveis-TLS og virksomhetssertifikater bibeholdes navnet Posten Norge AS all den tid det er navnet som inntil videre er i  bruk på selve sertifikatet.