### PR TITLE
Add readthedocs v2 config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: source/conf.py
+  fail_on_warning: true
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+python:
+  install:
+  - requirements: requirements.txt


### PR DESCRIPTION
Adds a configuration file `.readthedocs.yaml`, as readthedocs stopped supporting "click-opsing" the settings in their GUI
https://blog.readthedocs.com/migrate-configuration-v2/

(this is a good thing 👏 )

Smooth migration, pretty much using the minimal template with an additional reference to requirements.txt file for the sphinx-tabs dependency.

The site built using the configuration ~is~ was available here https://signering-docs.readthedocs.io/en/readthedocs-config/, and seems to work as it should.

