### PR TITLE
.NET TLS 1.2 note + small site fixups

### DIFF
--- a/source/client-integration/create-client-configuration.rst
+++ b/source/client-integration/create-client-configuration.rst
@@ -57,6 +57,11 @@ A client configuration includes all organization specific configuration and all 
           return new X509Certificate2(certificatePath, certificatePassword, X509KeyStorageFlags.Exportable);
 
 
+      ..  NOTE::
+
+          TLS 1.2 must be enabled to connect to Posten signering. If this is not the case, please set security protocol using the following statement:
+          ``ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;``. If the protocol is not enabled, please refer to the following `Microsoft Documentation for enabling TLS 1.2 <https://docs.microsoft.com/en-us/sccm/core/plan-design/security/enable-tls-1-2>`_.
+
 
     ..  group-tab:: Java
 

--- a/source/client-integration/create-client-configuration.rst
+++ b/source/client-integration/create-client-configuration.rst
@@ -7,6 +7,57 @@ A client configuration includes all organization specific configuration and all 
 
 ..  tabs::
 
+  ..  group-tab:: C#
+
+
+      .. NOTE::
+         SEID 2.0 enterprise certificates
+
+          If you have a SEID 2.0 enterprise certificate from Buypass, you need to use at least version `8.1.0 <https://github.com/digipost/signature-api-client-dotnet/releases/tag/8.1.0>`_ of the dotnet client library.
+          If this is not possible, or you have a SEID 2.0 enterprise certificate from Commfies, you need to disable validation of the enterprise certificate when configuring your client. The certificate will always be validated on our server, so it will not impact
+          the security of the request. The client side validation is only there to help identify errors early on.
+
+
+      ..  code-block:: c#
+
+          const string organizationNumber = "123456789";
+
+          var clientConfiguration = new ClientConfiguration(
+              Environment.DifiTest,
+              return new X509Certificate2(certificatePath, certificatePassword),
+              new Sender(organizationNumber)
+          )
+          {
+              // This is only needed if you have a SEID 2.0 certificate, but for some reason cannot use the latest version of the library,
+              // or if you have a SEID 2.0 certificate from Commfides
+              CertificateValidationPreferences = { ValidateSenderCertificate = false }
+          };
+
+      If you stored the `certificatePath` and `certificatePassword` in the Secret Manager, you can read it like this:
+
+      ..  code-block:: c#
+
+          var pathToSecrets = $"{System.Environment.GetEnvironmentVariable("HOME")}/.microsoft/usersecrets/enterprise-certificate/secrets.json";
+          _logger.LogDebug($"Reading certificate details from secrets file: {pathToSecrets}");
+
+          var fileExists = File.Exists(pathToSecrets);
+          if (!fileExists)
+          {
+              _logger.LogDebug($"Did not find file at {pathToSecrets}");
+          }
+
+          var certificateConfig = File.ReadAllText(pathToSecrets);
+          var deserializeObject = JsonConvert.DeserializeObject<Dictionary<string, string>>(certificateConfig);
+
+          deserializeObject.TryGetValue("Certificate:Path:Absolute", out var certificatePath);
+          deserializeObject.TryGetValue("Certificate:Password", out var certificatePassword);
+
+          _logger.LogDebug("Reading certificate from path found in secrets file: " + certificatePath);
+
+          return new X509Certificate2(certificatePath, certificatePassword, X509KeyStorageFlags.Exportable);
+
+
+
     ..  group-tab:: Java
 
         The first step is to load the enterprise certificate (virksomhetssertifikat) through the :code:`KeyStoreConfig`. It can be created from a Java Key Store (JKS) or directly from a PKCS12-container, which is the usual format of an enterprise certificate. The latter is the recommended way of loading it if you have the certificate stored as a simple file:
@@ -45,55 +96,6 @@ A client configuration includes all organization specific configuration and all 
                     .serviceUri(ServiceUri.DIFI_TEST)
                     .globalSender(new Sender("123456789"))
                     .build();
-
-    ..  group-tab:: C#
-
-
-        .. NOTE::
-           SEID 2.0 enterprise certificates
-
-            If you have a SEID 2.0 enterprise certificate from Buypass, you need to use at least version `8.1.0 <https://github.com/digipost/signature-api-client-dotnet/releases/tag/8.1.0>`_ of the dotnet client library.
-            If this is not possible, or you have a SEID 2.0 enterprise certificate from Commfies, you need to disable validation of the enterprise certificate when configuring your client. The certificate will always be validated on our server, so it will not impact
-            the security of the request. The client side validation is only there to help identify errors early on.
-
-
-        ..  code-block:: c#
-
-            const string organizationNumber = "123456789";
-
-            var clientConfiguration = new ClientConfiguration(
-                Environment.DifiTest,
-                return new X509Certificate2(certificatePath, certificatePassword),
-                new Sender(organizationNumber)
-            )
-            {
-                // This is only needed if you have a SEID 2.0 certificate, but for some reason cannot use the latest version of the library,
-                // or if you have a SEID 2.0 certificate from Commfides
-                CertificateValidationPreferences = { ValidateSenderCertificate = false }
-            };
-
-        If you stored the `certificatePath` and `certificatePassword` in the Secret Manager, you can read it like this:
-
-        ..  code-block:: none
-
-            var pathToSecrets = $"{System.Environment.GetEnvironmentVariable("HOME")}/.microsoft/usersecrets/enterprise-certificate/secrets.json";
-            _logger.LogDebug($"Reading certificate details from secrets file: {pathToSecrets}");
-
-            var fileExists = File.Exists(pathToSecrets);
-            if (!fileExists)
-            {
-                _logger.LogDebug($"Did not find file at {pathToSecrets}");
-            }
-
-            var certificateConfig = File.ReadAllText(pathToSecrets);
-            var deserializeObject = JsonConvert.DeserializeObject<Dictionary<string, string>>(certificateConfig);
-
-            deserializeObject.TryGetValue("Certificate:Path:Absolute", out var certificatePath);
-            deserializeObject.TryGetValue("Certificate:Password", out var certificatePassword);
-
-            _logger.LogDebug("Reading certificate from path found in secrets file: " + certificatePath);
-
-            return new X509Certificate2(certificatePath, certificatePassword, X509KeyStorageFlags.Exportable);
 
 
 ..  NOTE::

--- a/source/client-integration/create-client-configuration.rst
+++ b/source/client-integration/create-client-configuration.rst
@@ -14,7 +14,7 @@ A client configuration includes all organization specific configuration and all 
          SEID 2.0 enterprise certificates
 
           If you have a SEID 2.0 enterprise certificate from Buypass, you need to use at least version `8.1.0 <https://github.com/digipost/signature-api-client-dotnet/releases/tag/8.1.0>`_ of the dotnet client library.
-          If this is not possible, or you have a SEID 2.0 enterprise certificate from Commfies, you need to disable validation of the enterprise certificate when configuring your client. The certificate will always be validated on our server, so it will not impact
+          If this is not possible, or you have a SEID 2.0 enterprise certificate from Commfides, you need to disable validation of the enterprise certificate when configuring your client. The certificate will always be validated on our server, so it will not impact
           the security of the request. The client side validation is only there to help identify errors early on.
 
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -20,7 +20,7 @@
 # -- Project information -----------------------------------------------------
 
 project = u'Posten signering documentation'
-copyright = u'2019, Posten Bring AS'
+copyright = u'2023, Posten Bring AS'
 author = u'Posten Bring AS'
 
 # The short X.Y version

--- a/source/conf.py
+++ b/source/conf.py
@@ -31,8 +31,8 @@ release = u'1'
 html_context = {
     "display_github": True, # Integrate GitHub
     "github_user": "digipost", # Username
-    "github_repo": "signering-doc", # Repo name
-    "github_version": "master", # Version
+    "github_repo": "signering-docs", # Repo name
+    "github_version": "main", # Version
     "conf_py_path": "/source/", # Path in the checkout to the docs root
 }
 


### PR DESCRIPTION
Konsoliderer og tar inn disse endringene https://github.com/digipost/signering-docs/compare/068b4a4a918d87bad1b069...aa1beb7e8ee5886ade4b11f77eae15d1ed591a19 (branch [fjern-global-tls-config](https://github.com/digipost/signering-docs/tree/fjern-global-tls-config))

Er [denne notisen](https://github.com/digipost/signering-docs/pull/50/commits/47165512a2033e041d1070a4bc15c39978037e66) ang. å enable TLS 1.2 relevant i dag?
<img width="775" alt="tls-12" src="https://github.com/digipost/signering-docs/assets/174823/3428ac4b-565c-4310-b72d-70e2ef0cd5fc">
Vi har tydeligvis ikke trengt å ha dette i dokumentasjonen tidligere.

Har kun gjort den logiske byttingen av rekkefølgen på C# og Java-fanene i b8800aee42d886793763688f6d8e621eecc51f2f, ikke tatt inn koden fra den opprinnelige commiten

Skulle gjerne kunnet legge til @asjafjell som reviewer på denne 😆 