### PR TITLE
Use 'signer' instead of 'recipient', and add note about included information in the signed document

### DIFF
--- a/source/adressering-av-undertegner.rst
+++ b/source/adressering-av-undertegner.rst
@@ -7,7 +7,7 @@ You may address signers for :ref:`portal flow <signing-in-portal-flow>` in two d
 1. By email and/or SMS (only available for private organizations)
 2. By national identity number
 
-The signed document will only include signatures from these signers, so remember to include signers from the sender side as well, if necessary.
+The signed document will only include signatures from the *addressed* signers, so remember to include signers from the sender side as well, if applicable.
 
 ..  CAUTION::
     How you choose to address the signer(s) affects the :ref:`content and appearance of the signature(s) in the resulting signed document <identify-signers>`.

--- a/source/adressering-av-undertegner.rst
+++ b/source/adressering-av-undertegner.rst
@@ -7,6 +7,8 @@ You may address signers for :ref:`portal flow <signing-in-portal-flow>` in two d
 1. By email and/or SMS (only available for private organizations)
 2. By national identity number
 
+The signed document will only include signatures from these signers, so remember to include signers from the sender side as well, if necessary.
+
 ..  CAUTION::
     How you choose to address the signer(s) affects the :ref:`content and appearance of the signature(s) in the resulting signed document <identify-signers>`.
 
@@ -16,7 +18,7 @@ You may address signers for :ref:`portal flow <signing-in-portal-flow>` in two d
 .. NOTE::
    This option is only available for private organizations
 
-When addressing signers by email/SMS, we will not be able to link signers to their national identity number. Therefore, we do not have any way to verify that the correct person is reading and signing. The recipients receive an email and/or SMS with a unique code and link to access the document(s) to sign, instead of being required to log in. See :ref:`notifications <notifications-without-national-identity>` to review what the notifications look like.
+When addressing signers by email/SMS, we will not be able to link signers to their national identity number. Therefore, we do not have any way to verify that the correct person is reading and signing. The signers receive an email and/or SMS with a unique code and link to access the document(s) to sign, instead of being required to log in. See :ref:`notifications <notifications-without-national-identity>` to review what the notifications look like.
 
 
 ..  IMPORTANT::
@@ -28,7 +30,7 @@ See :ref:`Signing in portal flow with addressing by e-mail / SMS <signing-in-por
 
 2. Addressing signers by their national identity number
 =======================================================
-If you know the national identity numbers of the signers, you can address them using their identity numbers. This is the most secure way to reach the expected recipients, since it requires them to log in with an electronic ID in order to read and sign.
+If you know the national identity numbers of the signers, you can address them using their identity numbers. This is the most secure way to reach the expected signers, since it requires them to log in with an electronic ID in order to read and sign.
 
 Even if the signer is addressed using a national identity number, the signer will be notified and will receive a link to log in by email or SMS – see :ref:`notification and contact details <notifications>` for more information..
 

--- a/source/send-dokument-avsenderportalen.rst
+++ b/source/send-dokument-avsenderportalen.rst
@@ -19,14 +19,14 @@ A signer can be addressed in two different ways, with or without a national iden
 - **Without national identity number**: This signing method does not require any login, and as the sender you do not need to know the signer's national identity number. Instead, you just need to enter email address and/or mobile phone number and the signer will receive a link to the document and fill in the security code provided in the notification. The signer can then open and sign the document using BankID, BankID mobile phone, or Buypass.
 
 
-Step 2: Recipients
+Step 2: Signers
 ===================
 
 For signers to receive notifications of signature requests, you must enter their contact details here. A signature request can have a maximum of 10 signers.
 
 As the sender, you may be the signer for your own signature request. If you tick **I will sign myself**, the email address you have registered for your user will be filled in automatically.
 
-Step 3: Information for recipients
+Step 3: Information for signers
 ===================================
 
 **Description of the document that is displayed in the notification email**:

--- a/source/signert-dokument.rst
+++ b/source/signert-dokument.rst
@@ -4,6 +4,9 @@ Signed documents
 ====================
 With a digital signature, documents can be signed electronically by using verification of a person's identity and linking this with one or more documents. For signed PDF documents, the signature data is contained in the file itself, and many PDF readers have the option of displaying the digital signature.
 
+..  NOTE::
+  The signed document will only include information about the signers and the content of the document. It will not include any information about the sending organization. If the document needs to be signed by the organization as well, a signer from the organization must be addressed as well. 
+
 When signing has been completed, we receive a *technical signature* and a *signed PDF*.
 
 A technical signature is an XML file called *XML Advanced Electronic Signature (XAdES)* and is the proof that you have signed digitally. XAdES contains data to verify who signed, the time of signing, which signing method was used, the IP address used by the signer, and whether the document has been changed since the time of signing.

--- a/source/varsler-til-avsender.rst
+++ b/source/varsler-til-avsender.rst
@@ -14,7 +14,7 @@ Notifications are sent to the sender in three cases:
 
 2. **24 hours before the signing deadline for a request expires**: The notification is sent out as a reminder to the sender that someone still has not signed. The sender can then choose to defer the signing deadline, or remind the signers by sending an extra notification. **NB:** The notification is only sent if the request's original signing deadline was more than 48 hours.
 
-3. **Four days before archiving of the signed document expires**: The notification is sent out as a reminder to the sender if the documents have been signed by all recipients, and *only* if the sender has not downloaded the signed document. Posten signering offers :ref:`long-term-validation-and-storage` for senders who do not want to have to download and retain signed documents.
+3. **Four days before archiving of the signed document expires**: The notification is sent out as a reminder to the sender if the documents have been signed by everyone, and *only* if the sender has not downloaded the signed document. Posten signering offers :ref:`long-term-validation-and-storage` for senders who do not want to have to download and retain signed documents.
 
 
 Notification when signature request changes status (in Norwegian)

--- a/source/varsler-til-undertegner.rst
+++ b/source/varsler-til-undertegner.rst
@@ -41,7 +41,7 @@ Signing deadline 1. notification: e-mail/SMS 2. notification: e-mail/SMS
 
 .. NOTE:: If the sender *extends the signing deadline*, all scheduled notifications for the request will be deleted. New notifications will then be generated and sent out at an appropriate time in relation to the new deadline.
 
-.. CAUTION:: To avoid accidentally sending notifications to actual recipients in test environments, a security mechanism has been included in difitest and difiqa: email notifications include a sentence to indicate that the notification comes from a test environment: ''This is a test email sent for Difi from Posten signering" and the SMS notifications are replaced in their entirety with the sentence: "This is a test SMS sent for Difi from Posten signering".
+.. CAUTION:: To avoid accidentally sending notifications to actual persons in test environments, a security mechanism has been included in difitest and difiqa: email notifications include a sentence to indicate that the notification comes from a test environment: ''This is a test email sent for Difi from Posten signering" and the SMS notifications are replaced in their entirety with the sentence: "This is a test SMS sent for Difi from Posten signering".
 
 
 Signer notification texts


### PR DESCRIPTION
To make it more clear that senders must address all signers, including someone from their own organization if it is needed.

Ny versjon av docs: https://signering-docs.readthedocs.io/en/sender-can-be-signer/