### PR TITLE
Virtualenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ packages
 .idea/
 .vs
 /build
+.python-version

--- a/README.md
+++ b/README.md
@@ -6,23 +6,43 @@ Sources for building the documentation site at [signering-docs.readthedocs.io](h
 
 ## ✅ Prerequisites
 
-1. **Install Python 3**
+1. **Install pyenv for managing Python versions**
+
+   ```shell
+   brew install pyenv pyenv-virtualenv
+   ```
+
+   And add the following snippet to your `.zshrc` or any other startup script for your shell:
+
+   ```shell
+   "$(pyenv init -)"
+   if which pyenv-virtualenv-init > /dev/null; then eval "$(pyenv virtualenv-init -)"; fi
+   ```
+
+   Open a new shell (terminal window) to ensure pyenv is initialized. Check available versions of Python with this command: (long list)
+
+   ```shell
+   pyenv install -l
+   ```
+
+
+2. **Install Python 3.11**
 
    Building the documentation site with [Sphinx](http://www.sphinx-doc.org) requires Python v3:
 
    ```shell
-   brew install python
+   pyenv install 3.11.7
    ```
+   Feel free to substitute the version with any later available 3.11.x version.
 
-2. **Link Python 3**
 
-   Link ``python3`` as described in [Stackoverflow](https://stackoverflow.com/a/49711594/1765749). By adding it first in `PATH` environment variable, it will be chosen before the really old one installed by default on macOS.
+3. **Set up virtualenv and dependencies**
 
-3. **Install dependencies for building the documentation**
+   Change to folder of your cloned working copy of this repository.
 
    ```shell
+   pyenv virtualenv 3.11.7 signering-docs
    pip install -r requirements.txt
-   pip install sphinx-autobuild
    ```
 
 4. **Do a build to verify everything works**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sphinx_rtd_theme==1.3.0
 sphinx-tabs==3.4.1
+sphinx-autobuild==2021.3.14

--- a/source/signaturtype.rst
+++ b/source/signaturtype.rst
@@ -7,7 +7,7 @@ In Norway, we have three different types of digital signature, as described in t
 
 We offer standard and advanced signature, which are legally valid signatures on a par with a handwritten signature. Qualified signature does not currently exist, but is intended to be achieved in the longer term via the National ID card.
 
-..  _advanced-signature:
+.. _advanced-signature:
 
 Advanced signature
 ==================
@@ -19,7 +19,7 @@ An advanced signature has a stronger connection between the signature and the do
 ..  TIP::
     Signing can take place using BankID, Buypass or BankID mobile phone. [#footnoteSigneringsmetoderOffentlig]_
 
-..  _authenticated-signature:
+.. _authenticated-signature:
 
 Authenticated signature
 ========================

--- a/source/signert-dokument.rst
+++ b/source/signert-dokument.rst
@@ -31,8 +31,8 @@ When the sender is a private organization:
 When the sender is a public organization:
 
 - Name + national identity number
-- Name + date of birth (only available for :ref:`_advanced-signature`)
-- Name (only available for :ref:`_authenticated-signature`)
+- Name + date of birth (only available for :ref:`advanced-signature`)
+- Name (only available for :ref:`authenticated-signature`)
 
 ..  CAUTION::
   If you want the signer’s national identity number to be shown on the signed document, for privacy reasons you must address the signer by national identity number in the signature request.


### PR DESCRIPTION
Changes instruction for working with the repository using Python pyenv + virtualenv, instead of awkwardly juggling Python versions with homebrew.

Also fixes a couple of broken references.