### PR TITLE
Remove notes on requiring National ID

### DIFF
--- a/source/client-integration/direct-flow.rst
+++ b/source/client-integration/direct-flow.rst
@@ -212,12 +212,16 @@ When using direct flow you can identify the signer in two different ways:
         ..  code-block:: c#
 
             //This functionality exists in C#, but the example has not been generated yet.
+            //For now, please refer to the HTTP tab, as the concepts described there have
+            //equivalent representations in the .NET client library.
 
     ..  group-tab:: Java
 
         ..  code-block:: java
 
             //This functionality exists in Java, but the example has not been generated yet.
+            //For now, please refer to the HTTP tab, as the concepts described there have
+            //equivalent representations in the Java client library.
 
     ..  group-tab:: HTTP
 
@@ -273,12 +277,16 @@ Identifier in the signed document
         ..  code-block:: c#
 
             //This functionality exists in C#, but the example has not been generated yet.
+            //For now, please refer to the HTTP tab, as the concepts described there have
+            //equivalent representations in the .NET client library.
 
     ..  group-tab:: Java
 
         ..  code-block:: java
 
             //This functionality exists in Java, but the example has not been generated yet.
+            //For now, please refer to the HTTP tab, as the concepts described there have
+            //equivalent representations in the Java client library.
 
     ..  group-tab:: HTTP
 
@@ -294,12 +302,16 @@ Status retrieval method
         ..  code-block:: c#
 
             //This functionality exists in C#, but the example has not been generated yet.
+            //For now, please refer to the HTTP tab, as the concepts described there have
+            //equivalent representations in the .NET client library.
 
     ..  group-tab:: Java
 
         ..  code-block:: java
 
             //This functionality exists in Java, but the example has not been generated yet.
+            //For now, please refer to the HTTP tab, as the concepts described there have
+            //equivalent representations in the Java client library.
 
     ..  group-tab:: HTTP
 
@@ -317,12 +329,16 @@ Response
         ..  code-block:: c#
 
             //This functionality exists in C#, but the example has not been generated yet.
+            //For now, please refer to the HTTP tab, as the concepts described there have
+            //equivalent representations in the .NET client library.
 
     ..  group-tab:: Java
 
         ..  code-block:: java
 
             //This functionality exists in Java, but the example has not been generated yet.
+            //For now, please refer to the HTTP tab, as the concepts described there have
+            //equivalent representations in the Java client library.
 
     ..  group-tab:: HTTP
 
@@ -642,6 +658,8 @@ After receiving a status change, the documents can be deleted as follows:
         ..  code-block:: c#
 
             //This functionality exists in C#, but the example has not been generated yet.
+            //For now, please refer to the Java tab, as the API and concepts described there have
+            //equivalent representations in the .NET client library.
 
     ..  group-tab:: Java
 

--- a/source/client-integration/portal-flow.rst
+++ b/source/client-integration/portal-flow.rst
@@ -218,8 +218,6 @@ Adressing the signer
 
             ..  tab:: E-mail
 
-                ..  NOTE:: This option is only available for organisations in private sector
-
                 ..  code-block:: xml
 
                     <signer>
@@ -232,8 +230,6 @@ Adressing the signer
 
             ..  tab:: Mobile
 
-                ..  NOTE:: This option is only available for organisations in private sector
-
                 ..  code-block:: xml
 
                     <signer>
@@ -245,8 +241,6 @@ Adressing the signer
                     </signer>
 
             ..  tab:: E-mail and mobile
-
-                ..  NOTE:: This option is only available for organisations in private sector
 
                 ..  code-block:: xml
 

--- a/source/client-integration/portal-flow.rst
+++ b/source/client-integration/portal-flow.rst
@@ -205,12 +205,16 @@ Adressing the signer
         ..  code-block:: c#
 
             //This functionality exists in C#, but the example has not been generated yet.
+            //For now, please refer to the HTTP tab, as the concepts described there have
+            //equivalent representations in the .NET client library.
 
     ..  group-tab:: Java
 
         ..  code-block:: java
 
             //This functionality exists in Java, but the example has not been generated yet.
+            //For now, please refer to the HTTP tab, as the concepts described there have
+            //equivalent representations in the Java client library.
 
     ..  group-tab:: HTTP
 
@@ -593,6 +597,8 @@ After receiving a status change, the documents can be deleted as follows:
         ..  code-block:: c#
 
             //This functionality exists in C#, but the example has not been generated yet.
+            //For now, please refer to the Java tab, as the API and concepts described there have
+            //equivalent representations in the .NET client library.
 
     ..  group-tab:: Java
 

--- a/source/client-integration/portal-flow.rst
+++ b/source/client-integration/portal-flow.rst
@@ -271,7 +271,10 @@ Adressing the signer
                 With notification as public organization:
 
                 ..  NOTE::
-                    Public organizations must use Kontakt- og Reservasjonsregisteret as lookup method.
+                    Public organizations collecting personal signatures should mainly address signers by their
+                    national ID, which mandates the use of Kontakt- og Reservasjonsregisteret for resolving their
+                    preferred contact information used for notifications of the signature job, and also to enforce
+                    their preference in case they opt-out from digital communication from the public sector.
 
                 ..  code-block:: xml
 


### PR DESCRIPTION
Previously for the public sector, addressing signers required the use of their national ID. This is **no longer the case**:
![remove-nationalid-restriction-note](https://github.com/digipost/signering-docs/assets/174823/0b975321-c863-466a-83e3-9a4a9317b813)


---

Included **a bit more elaborate note about the motivation to use national ID as identifier**:
![nationalid-motivational-speech](https://github.com/digipost/signering-docs/assets/174823/5cbd94d5-97e7-4f7e-aa5a-c4d23d9e96de)

---

Until we get our thumbs out and manages to provide some code examples for the missing bits, **refer to the HTTP tab, which should provide hints on what to look for in either the .NET or the Java client libraries:**

![refer-to-http](https://github.com/digipost/signering-docs/assets/174823/dfa1ba1f-5023-4398-af56-cc96640da22a)
