### PR TITLE
Remove references to difiqa environment

### DIFF
--- a/source/client-integration/archive-client.rst
+++ b/source/client-integration/archive-client.rst
@@ -48,7 +48,7 @@ See :ref:`client-configuration` for instructions on how to set up the configurat
             To download a document, send an ``HTTP GET`` request to ``api.<env>.signering.posten.no/api/<organization-num>/archive/documents/<id>/pades``.
 
 
-            - ``<env>`` is difiqa, difitest, or just remove the environment part for the production environment.
+            - ``<env>`` is difitest, or just remove the environment part for the production environment.
             - ``<organization-num>`` is the organization number whose archive you want to access
             - ``<id>`` is the ID of the document you want to download.
             - The ending ``/pades`` indicates the variant of the document you want to download, and at this point only signed documents (PAdES) is supported. For more information on the format of the signed document, see :ref:`signed-documents`.

--- a/source/client-integration/direct-flow.rst
+++ b/source/client-integration/direct-flow.rst
@@ -101,7 +101,7 @@ Step 1: Create signature job
 
         The flow starts when the sender sends a request to create the signature job to the API. This request is a `multipart message <https://en.wikipedia.org/wiki/MIME#Multipart_messages>`_ comprised of a document bundle part and a metadata part.
 
-        - The request is a ``HTTP POST`` to the resource ``api.<environment>.signering.posten.no/api/<organization-number>/direct/signature-jobs``, where ``<environment>`` is ``difiqa``, ``difitest`` or just remove the environment part for the production environment.
+        - The request is a ``HTTP POST`` to the resource ``api.<environment>.signering.posten.no/api/<organization-number>/direct/signature-jobs``, where ``<environment>`` is ``difitest`` or just remove the environment part for the production environment.
         - The document bundle is added to the multipart message with ``application/octet-stream`` as media type. See :ref:`information-about-document-package` for more information on the document bundle.
         - The metadata in the multipart request is defined by the ``direct-signature-job-request`` element. These are added with media type ``application/xml``.
 

--- a/source/client-integration/portal-flow.rst
+++ b/source/client-integration/portal-flow.rst
@@ -105,7 +105,7 @@ Step 1: Create signature job
         The flow starts when the sender sends a request to create the signature job to the API. This request is a `multipart message <https://en.wikipedia.org/wiki/MIME#Multipart_messages>`_ comprised of a document bundle part and a metadata part.
 
 
-        - The request is a ``HTTP POST`` to the resource ``api.<environment>.signering.posten.no/api/<organization-number>/portal/signature-jobs``, where ``<environment>`` is ``difiqa``, ``difitest`` or just remove the environment part for the production environment.
+        - The request is a ``HTTP POST`` to the resource ``api.<environment>.signering.posten.no/api/<organization-number>/portal/signature-jobs``, where ``<environment>`` is ``difitest`` or just remove the environment part for the production environment.
         - The document bundle is added to the multipart message with ``application/octet-stream`` as media type. See :ref:`information-about-document-package` for more information on the document bundle.
         - The metadata in the multipart request is defined by the ``portal-signature-job-request`` element. These are added with media type ``application/xml``.
 

--- a/source/varsler-til-undertegner.rst
+++ b/source/varsler-til-undertegner.rst
@@ -41,7 +41,7 @@ Signing deadline 1. notification: e-mail/SMS 2. notification: e-mail/SMS
 
 .. NOTE:: If the sender *extends the signing deadline*, all scheduled notifications for the request will be deleted. New notifications will then be generated and sent out at an appropriate time in relation to the new deadline.
 
-.. CAUTION:: To avoid accidentally sending notifications to actual persons in test environments, a security mechanism has been included in difitest and difiqa: email notifications include a sentence to indicate that the notification comes from a test environment: ''This is a test email sent for Digdir from Posten signering" and the SMS notifications are replaced in their entirety with the sentence: "This is a test SMS sent for Digdir from Posten signering".
+.. CAUTION:: To avoid accidentally sending notifications to actual persons in test environments, a security mechanism has been included in difitest: email notifications include a sentence to indicate that the notification comes from a test environment: ''This is a test email sent for Digdir from Posten signering" and the SMS notifications are replaced in their entirety with the sentence: "This is a test SMS sent for Digdir from Posten signering".
 
 
 Signer notification texts


### PR DESCRIPTION
The `difiqa`-environment no longer exists. Removing references to it.
