### PR TITLE
Add info regarding notifications in digipost when applicable

### DIFF
--- a/source/adressering-av-undertegner.rst
+++ b/source/adressering-av-undertegner.rst
@@ -29,7 +29,7 @@ See :ref:`Signing in portal flow with addressing by e-mail / SMS <signing-in-por
 =======================================================
 If you know the national identity numbers of the signers, you can address them using their identity numbers. This is the most secure way to reach the expected signers, since it requires them to log in with an electronic ID in order to read and sign.
 
-Even if the signer is addressed using a national identity number, the signer will be notified and will receive a link to log in by email or SMS – see :ref:`notification and contact details <notifications>` for more information.
+Even if the signer is addressed using a national identity number, the signer will be notified and will receive a link to log in by email, SMS or in Digipost – see :ref:`notification and contact details <notifications>` for more information.
 
 
 ..  TIP::
@@ -52,6 +52,8 @@ When you select signing in portal flow, emails and/or SMS notifications are sent
 For private organizations
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 If the sender is a **private organization**, you must yourself enter the email address and/or mobile number of the recipient. This also applies if you address the signer using national identity number. Private organizations cannot use KRR.
+
+If you address signers by their national identity number and they have a Digipost account, the notification will be sent to their Digipost inbox. If they do not have a Digipost account, the notification will be sent by email and/or SMS as described above.
 
 For public organizations
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/gdpr.rst
+++ b/source/gdpr.rst
@@ -7,7 +7,7 @@ On a general basis, data that we no longer need is erased after 3 years. Erasure
 Notifications
 #############
 
-We erase email and SMS notifications 3 years after the last time sending them was attempted.
+We erase email, SMS and Digipost notifications 3 years after the last time sending them was attempted.
 
 
 Signature requests

--- a/source/send-dokument-avsenderportalen.rst
+++ b/source/send-dokument-avsenderportalen.rst
@@ -29,14 +29,14 @@ As the sender, you may be the signer for your own signature request. If you tick
 Step 3: Information for signers
 ===================================
 
-**Description of the document that is displayed in the notification email**:
-As the description will appear in the email that is sent out, it should not include any sensitive information. It is nonetheless a good idea to include details of what is to be signed, to make it easier for the signer to identify in the email.
+**Description of the document that is displayed in the notifications**:
+As the description will appear in all notifications that are sent to the signers, it should not include any sensitive information. It is nonetheless a good idea to include details of what is to be signed, to make it easier for the signers to identify it.
 
 **Title of the front page of the signed document**:
 The title appears on the front page of the signed document. :ref:`Read more about the content of the signed document here <signed-documents>`.
 
 **Message that the recipient sees in the signature portal**:
-Write a personal message to the signer. The message is displayed before the documents are signed (not sent by email or SMS).
+Write a personal message to the signer. The message is displayed before the documents are signed (not included in notifications).
 
 **Internal case number/reference ID**:
 If you have a case number or reference ID linked to the documents or signer, you can write it here. It can be used for easier retrieval of the documents.

--- a/source/signeringsflyt.rst
+++ b/source/signeringsflyt.rst
@@ -39,7 +39,7 @@ If you use a national identity number as the address, the signer will have to lo
 The flow typically looks like this:
 
 #. The sender creates a signature request via API or online in the sender portal
-#. Posten signering notifies the signer by email (and, if applicable, SMS if specificed upon registration)
+#. Posten signering notifies the signer (by email, SMS or in Digipost)
 #. The signer logs into the signature portal and signs the document
 #. The signer downloads a signed document
 #. The signer logs out of the signature portal

--- a/source/varsler-til-undertegner.rst
+++ b/source/varsler-til-undertegner.rst
@@ -37,6 +37,8 @@ Signing deadline 1. notification: e-mail/SMS 2. notification: e-mail/SMS
 
    <!-- Tabellen er generert vha. http://www.tablesgenerator.com/markdown_tables -->
 
+.. NOTE:: If the sender is a private organization, the signer is adressed by personal identification number and the signer has a Digipost account, the email notifications will be replaced by messages in Digipost.
+
 .. NOTE:: No SMS is sent between 22:00 and 8:00, unless the request is created at night and the deadline is so short that it has to be sent immediately.
 
 .. NOTE:: If the sender *extends the signing deadline*, all scheduled notifications for the request will be deleted. New notifications will then be generated and sent out at an appropriate time in relation to the new deadline.
@@ -74,7 +76,7 @@ ________________________________________________________________________________
 
         Les og signer innen: [*signeringsfrist*]
 
-        Du signerer enkelt og trygt med [*disse elektroniske e-IDene*].
+        Du signerer enkelt og trygt med elektronisk ID.
 
         Logg deg inn på [*signering.posten.no/logginn*] for å lese og signere.
 
@@ -91,7 +93,7 @@ ________________________________________________________________________________
 
         Dokumentet(ene) er nå signert av [*antall*] og må signeres innen [*signeringsfrist*].
 
-        Du signerer enkelt og trygt med [*disse elektroniske e-IDene*].
+        Du signerer enkelt og trygt med elektronisk ID.
 
         Logg deg inn på [*signering.posten.no/logginn*] for å lese og signere.
 
@@ -125,7 +127,7 @@ ____________________________________________________________________
 
         Les og signer innen: [*signeringsfrist*].
 
-        Du signerer enkelt og trygt med [*disse elektroniske ID-ene*].
+        Du signerer enkelt og trygt med elektronisk ID.
 
         Slik signerer du:
         1) Klikk på lenken under
@@ -145,7 +147,7 @@ ____________________________________________________________________
 
         Les og signer innen: [*signeringsfrist*].
 
-        Du signerer enkelt og trygt med [*disse elektroniske ID-ene*].
+        Du signerer enkelt og trygt med elektronisk ID.
 
         Slik signerer du:
         1) Klikk på lenken under
@@ -191,7 +193,7 @@ Private senders
 
         Du har nettopp signert et dokument fra [*Avsender*] gjennom Posten signering.
 
-        Hvis du oppretter en konto i Digipost innen 7 dager, sendes dokumentet du signerte automatisk dit. Da har du det              lett tilgjengelig når du trenger det!
+        Hvis du oppretter en konto i Digipost innen 7 dager, sendes dokumentet du signerte automatisk dit. Da har du det lett tilgjengelig når du trenger det!
 
         Registrer deg i Digipost: https://www.digipost.no/app/registrering ,
 


### PR DESCRIPTION
For now it's only available when three conditions are met: when the sender is a private organization, when the signer is adressed by personal identification number, and when the signer has a Digipost account.