### PR TITLE
Dokumenter bruk og effekt av "ikke-sensitiv tittel"

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Sources for building the documentation site at [signering-docs.readthedocs.io](h
    Building the documentation site with [Sphinx](http://www.sphinx-doc.org) requires Python v3:
 
    ```shell
-   pyenv install 3.13.2
+   pyenv install 3.13.4
    ```
    Feel free to substitute the version with any later available 3.13.x version.
 
@@ -41,14 +41,14 @@ Sources for building the documentation site at [signering-docs.readthedocs.io](h
 
    Change to folder of your cloned working copy of this repository.
 
-   If you already have set up a virtualenv (your prompt includes "(signering-docs)"), and you want to upgrade its version of Python (`python --version` print a version earlier than 3.13.2), first delete the existing virtualenv:
+   If you already have set up a virtualenv (your prompt includes "(signering-docs)"), and you want to upgrade its version of Python (`python --version` print a version earlier than 3.13.4), first delete the existing virtualenv:
 
    ```shell
    pyenv virtualenv-delete signering-docs
    ```
 
    ```shell
-   pyenv virtualenv 3.13.2 signering-docs  #create a new virtualenv 'signering-docs'
+   pyenv virtualenv 3.13.4 signering-docs  #create a new virtualenv 'signering-docs'
    pyenv local signering-docs  #this sets up 'signering-docs' as the virtualenv to use here
    pip install -r requirements.txt
    ```

--- a/source/client-integration/portal-flow.rst
+++ b/source/client-integration/portal-flow.rst
@@ -460,6 +460,51 @@ In the case of signing on behalf of **"other"**, the features intended for priva
 Other settings
 ---------------------------
 
+.. _nonSensitiveTitle:
+
+Non-sensitive title
+^^^^^^^^^^^^^^^^^^^
+
+The *non-sensitive title* optional property of a signature job is used, if present, to refer to the signature job in any insecure contexts, notably in email and SMS notifications for the signers. Although optional, it is strongly recommended to specify a non-sensitive title, because this allows to display some contextual information about the document(s) when signers are invited to sign them, and this decreases the chance of the notification being dismissed as spam. If a non-sensitive title is not specified, the notifications will fall back to a generic text describing something along lines of "some documents to sign".
+
+It is perfectly fine to set both the title (mandatory) and non-sensitive title (optional) to be the *same text*, but care should be taken to not include any personal or sensitive information in the non-sensitive title which will be included in insecure communication, notably emails and SMSes.
+
+..  tabs::
+
+    ..  group-tab:: C#
+
+        ..  code-block:: c#
+
+            var portalJob = new Job("Job title", documentsToSign, signers, "myReferenceToJob")
+            {
+                NonSensitiveTitle = "Non-sensitive title, used in notifications"
+            };
+
+    .. group-tab:: Java
+
+        .. code-block:: java
+
+            PortalJob job = PortalJob
+                    .builder("Job title", documents, signers)
+                    .withNonSensitiveTitle("Non-sensitive title, used in notifications")
+                    .build();
+
+        See also the javadoc for `PortalJob.Builder <javadocPortalJobBuilder_>`_
+
+    .. group-tab:: HTTP
+
+        See the example given for :ref:`creating the job <portalIntegrationStep1>`, which includes the ``nonsensitive-title`` element in context.
+
+        .. code-block:: xml
+
+            <title>The main title, not included in notifications</title>
+            <nonsensitive-title>The non-sensitive title, used in notifications</nonsensitive-title>
+
+        See also the schema `portal.xsd, and the element named nonsensitive-title <xsdNonSensitiveTitle_>`_
+
+
+
+
 Order
 ^^^^^^^^^^^
 The ``order`` attribute on ``signer`` is used to specify the order of the signers. In the example above, the signature job will only be available to the signers with ``order = "1"``. Once signed, the job becomes available to those with ``order = "2"``, and for the signer with ``order = "3"`` when those with ``order = "2"`` have signed.
@@ -779,3 +824,5 @@ After receiving a status change, the documents can be deleted as follows:
 
 
 .. _KRR: https://samarbeid.digdir.no/kontaktregisteret/kontakt-og-reservasjonsregisteret/42
+.. _xsdNonSensitiveTitle: https://github.com/digipost/signature-api-specification/blob/3.1.0/schema/xsd/portal.xsd#L162-L177
+.. _javadocPortalJobBuilder: https://javadoc.io/doc/no.digipost.signature/signature-api-client-java/latest/no/digipost/signature/client/portal/PortalJob.Builder.html

--- a/source/varsler-til-undertegner.rst
+++ b/source/varsler-til-undertegner.rst
@@ -57,6 +57,7 @@ The content of the notification will vary according to
 - which channel the notifications are sent in (e-mail/SMS)
 - the sector from which the sender sends (private or public)
 - the number of signers for the request
+- whether a *non-sensitive title* has been specified or not (see section about :ref:`non-sensitive title for portal flow <nonSensitiveTitle>`)
 
 The different notification versions sent by email and SMS are shown below (in Norwegian).
 


### PR DESCRIPTION
Legger til nytt punkt under [Signer notification texts](https://signering-docs.readthedocs.io/en/latest/varsler-til-undertegner.html#signer-notification-texts) ang. ikke-sensitiv tittel for hvordan det påvirker innholdet i varsler:

<img width="719" alt="Screenshot 2025-06-12 at 13 52 12" src="https://github.com/user-attachments/assets/803cac53-587f-48b2-99f5-3a525a38a1ad" />

---

Lenken "see section about..." ☝️ leder videre til [portalflyt](https://signering-docs.readthedocs.io/en/latest/client-integration/portal-flow.html#other-settings) og ny beskrivelse av non-sensitive title:

---

<img width="780" alt="Screenshot 2025-06-12 at 13 52 43" src="https://github.com/user-attachments/assets/1ed7e54b-7658-4b1d-b146-e0e429891ba0" />

<details>
  <summary>Java</summary>
<img width="780" alt="Screenshot 2025-06-12 at 13 52 52" src="https://github.com/user-attachments/assets/a6186d94-dc78-44e1-976a-ee9bd1b7dcbb" />

</details>

<details>
  <summary>HTTP (XML)</summary>
<img width="780" alt="Screenshot 2025-06-12 at 13 52 59" src="https://github.com/user-attachments/assets/f02e2a5c-4c32-4e3c-9cc4-56e38bffbcb9" />

</details>
